### PR TITLE
Use CI tokens for GitHub Action auth

### DIFF
--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: mkdir $HOME && mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true
+        run: mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: spell server update --from-file $PWD/servers/config.yaml || true
+        run: mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: echo $(spell owner) && mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true
+        run: spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true
+        run: mkdir $HOME/.spell/ && spell keys generate && spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ci-tokens-flow
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true
+        run: echo "Hello" && mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: ls $HOME && ls $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true
+        run: mkdir $HOME && mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -20,11 +20,12 @@ jobs:
         shell: bash
         run: python3 -m pip install spell
       - name: log-into-spell
-        env:
-          CI_USER_PASSWORD: ${{ secrets.CI_USER_PASSWORD }}
         shell: bash
         run: spell login --identity github@spell.ml --password "$CI_USER_PASSWORD"
       # ci steps
       - name: update-model-server
+        env:
+          SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
+          SPELL_OWNER: "external-aws"
         shell: bash
         run: spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: spell server update --from-file $PWD/servers/config.yaml || true
+        run: ls $HOME && ls $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -20,9 +20,6 @@ jobs:
       - name: install-spell
         shell: bash
         run: python3 -m pip install spell
-      - name: log-into-spell
-        shell: bash
-        run: spell login --identity github@spell.ml --password "$CI_USER_PASSWORD"
       # ci steps
       - name: update-model-server
         env:

--- a/.github/workflows/update_model_server.yaml
+++ b/.github/workflows/update_model_server.yaml
@@ -26,4 +26,4 @@ jobs:
           SPELL_TOKEN: ${{ secrets.CI_TOKEN }}
           SPELL_OWNER: "external-aws"
         shell: bash
-        run: echo "Hello" && mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true
+        run: echo $(spell owner) && mkdir $HOME/.spell/ && spell server update --from-file $PWD/servers/config.yaml || true


### PR DESCRIPTION
- Use CI token instead of creds.
- Tweak rules.
